### PR TITLE
Add XL_CELL_NUMBER to xlrd __init__

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -305,7 +305,7 @@ import licences
 
 import sys, zipfile, pprint
 import timemachine
-from biffh import XLRDError, biff_text_from_num, error_text_from_code, XL_CELL_BLANK, XL_CELL_TEXT, XL_CELL_BOOLEAN, XL_CELL_ERROR, XL_CELL_EMPTY, XL_CELL_DATE, XL_CELL_DATE, XL_CELL_NUMBER
+from biffh import XLRDError, biff_text_from_num, error_text_from_code, XL_CELL_BLANK, XL_CELL_TEXT, XL_CELL_BOOLEAN, XL_CELL_ERROR, XL_CELL_EMPTY, XL_CELL_DATE, XL_CELL_NUMBER
 from formula import * # is constrained by __all__
 from book import colname #### TODO #### formula also has `colname` (restricted to 256 cols)
 from sheet import empty_cell
@@ -372,9 +372,9 @@ USE_MMAP = MMAP_AVAILABLE
 # @return An instance of the Book class.
 
 def open_workbook(filename=None,
-    logfile=sys.stdout, 
-    verbosity=0, 
-    pickleable=True, 
+    logfile=sys.stdout,
+    verbosity=0,
+    pickleable=True,
     use_mmap=USE_MMAP,
     file_contents=None,
     encoding_override=None,
@@ -432,7 +432,7 @@ def open_workbook(filename=None,
         ragged_rows=ragged_rows,
         )
     return bk
-    
+
 ##
 # For debugging: dump an XLS file's BIFF records in char & hex.
 # @param filename The path to the file to be dumped.


### PR DESCRIPTION
I tracked down a failure to open/write an excel file on a webapp we've built to a missing import. We were using the latest versions from git for xlrd, xlutils & xlwt.

The stack trace was:

```
---> 14 from xlutils.copy import copy
----> 7 from xlutils.filter import process,XLRDReader,XLWTWriter
---> 16 from xlutils.margins import cells_all_junk
---> 10     from xlrd import open_workbook, XL_CELL_EMPTY, XL_CELL_TEXT, XL_CELL_NUMBER

ImportError: cannot import name XL_CELL_NUMBER
```

When I checked the xlrd **init** it had a `from bffi import XL_...` but CELL_NUMBER was missing, which xlutils is looking to import in [all cases](https://github.com/python-excel/xlutils/blob/master/xlutils/margins.py#L5) in margins.py.
