### PR TITLE
Fix for issue #22 where output is not guarded by verbosity check

### DIFF
--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -750,9 +750,10 @@ class Book(BaseObject):
                 6: 'Visual Basic module',
                 }.get(sheet_type, 'UNKNOWN')
 
-            fprintf(self.logfile,
-                "NOTE *** Ignoring non-worksheet data named %r (type 0x%02x = %s)\n",
-                sheet_name, sheet_type, descr)
+            if DEBUG or self.verbosity >= 1:
+                fprintf(self.logfile,
+                    "NOTE *** Ignoring non-worksheet data named %r (type 0x%02x = %s)\n",
+                    sheet_name, sheet_type, descr)
         else:
             snum = len(self._sheet_names)
             self._all_sheets_map.append(snum)


### PR DESCRIPTION
This is a one-line fix to an issue potentially causing problems with specific WSGI setups (that disallow use of stdout)
