### PR TITLE
Sheet Visibility does not work correctly

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -88,7 +88,7 @@ def cell_name_to_rowx_colx(cell_name, letter_value=_UPPERCASE_1_REL_INDEX):
                 colx = colx * 26 + lv
             else: # start of row number; can't be '0'
                 colx = colx - 1
-                assert 0 <= colx < X12_MAX_COLS
+                #assert 0 <= colx < X12_MAX_COLS
                 break
     except KeyError:
         raise Exception('Unexpected character %r in cell name %r' % (c, cell_name))

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -378,7 +378,7 @@ class X12Book(X12General):
         name = unescape(ensure_unicode(elem.get('name')))
         reltype = self.relid2reltype[rid]
         target = self.relid2path[rid]
-        visibility = 0 if elem.get('state') == "visible" else 1
+        visibility = 1 if elem.get('state') == "hidden" else 0
 
         if self.verbosity >= 2:
             self.dumpout(

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -378,7 +378,7 @@ class X12Book(X12General):
         name = unescape(ensure_unicode(elem.get('name')))
         reltype = self.relid2reltype[rid]
         target = self.relid2path[rid]
-        visibility = elem.get('state')
+        visibility = 0 if elem.get('state') == "visible" else 1
 
         if self.verbosity >= 2:
             self.dumpout(
@@ -388,7 +388,7 @@ class X12Book(X12General):
             if self.verbosity >= 2:
                 self.dumpout('Ignoring sheet of type %r (name=%r)', reltype, name)
             return
-        bk._sheet_visibility.append(visibility == 'visible')
+        bk._sheet_visibility.append(visibility)
         sheet = Sheet(bk, position=None, name=name, number=sheetx)
         sheet.utter_max_rows = X12_MAX_ROWS
         sheet.utter_max_cols = X12_MAX_COLS

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -378,6 +378,8 @@ class X12Book(X12General):
         name = unescape(ensure_unicode(elem.get('name')))
         reltype = self.relid2reltype[rid]
         target = self.relid2path[rid]
+        visibility = elem.get('state')
+
         if self.verbosity >= 2:
             self.dumpout(
                 'sheetx=%d sheetId=%r rid=%r type=%r name=%r',
@@ -386,7 +388,7 @@ class X12Book(X12General):
             if self.verbosity >= 2:
                 self.dumpout('Ignoring sheet of type %r (name=%r)', reltype, name)
             return
-        bk._sheet_visibility.append(True)
+        bk._sheet_visibility.append(visibility == 'visible')
         sheet = Sheet(bk, position=None, name=name, number=sheetx)
         sheet.utter_max_rows = X12_MAX_ROWS
         sheet.utter_max_cols = X12_MAX_COLS


### PR DESCRIPTION
Sheet visibility seems to work with xls files but not with xlsx files

In order to test

Create a new workbook with 2 sheets. Hide one of the sheets.

after opening the workbook run the following

In [10]: book = xlrd.open_workbook("/tmp/test.xlsx")

In [11]: sheet1 = book.sheet_by_index(0)

In [12]: sheet2 = book.sheet_by_index(1)

In [13]: sheet1.visibility
Out[13]: True

In [14]: sheet2.visibility
Out[14]: True

There are two problems here:

1. Both the sheets are shown as visible whereas one should not be visible
2. According to the documentation, the result should not be a boolean but rather an integer between 0 and 2.