### PR TITLE
The check for file_contents didn't discriminate the argument missing and the file being empty

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -388,7 +388,7 @@ def open_workbook(filename=None,
     ragged_rows=False,
     ):
     peeksz = 4
-    if file_contents:
+    if file_contents is not None:
         peek = file_contents[:peeksz]
     else:
         f = open(filename, "rb")


### PR DESCRIPTION
With a default argument ie file_contents = None

Checking if file_contents has been provided using:
    if file_contents:

... returns False for an empty file. This leads to very tedious debugging if your file happens to be empty!
