### PR TITLE
Fix parsing dimensions in xlsx files

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -73,7 +73,8 @@ for _x in "123456789":
     _UPPERCASE_1_REL_INDEX[_x] = 0
 del _x
 
-def cell_name_to_rowx_colx(cell_name, letter_value=_UPPERCASE_1_REL_INDEX):
+def cell_name_to_rowx_colx(cell_name, letter_value=_UPPERCASE_1_REL_INDEX,
+        allow_no_col=False):
     # Extract column index from cell name
     # A<row number> => 0, Z =>25, AA => 26, XFD => 16383
     colx = 0
@@ -85,9 +86,18 @@ def cell_name_to_rowx_colx(cell_name, letter_value=_UPPERCASE_1_REL_INDEX):
             if lv:
                 colx = colx * 26 + lv
             else: # start of row number; can't be '0'
-                colx = colx - 1
-                assert 0 <= colx < X12_MAX_COLS
-                break
+                if charx == 0:
+                    # there was no col marker
+                    if allow_no_col:
+                        colx = None
+                        break
+                    else:
+                        raise Exception(
+                                'Missing col in cell name %r', cell_name)
+                else:
+                    colx = colx - 1
+                    assert 0 <= colx < X12_MAX_COLS
+                    break
     except KeyError:
         raise Exception('Unexpected character %r in cell name %r' % (c, cell_name))
     rowx = int(cell_name[charx:]) - 1
@@ -562,9 +572,11 @@ class X12Sheet(X12General):
         if ref:
             # print >> self.logfile, "dimension: ref=%r" % ref
             last_cell_ref = ref.split(':')[-1] # example: "Z99"
-            rowx, colx = cell_name_to_rowx_colx(last_cell_ref)
+            rowx, colx = cell_name_to_rowx_colx(
+                    last_cell_ref, allow_no_col=True)
             self.sheet._dimnrows = rowx + 1
-            self.sheet._dimncols = colx + 1
+            if colx is not None:
+                self.sheet._dimncols = colx + 1
 
     def do_merge_cell(self, elem):
         # The ref attribute should be a cell range like "B1:D5".


### PR DESCRIPTION
Note that this pull request is missing tests, but I want first to check that my approach is fine. The problem is that some xlsx files have the following start:

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
<sheetPr filterMode="false">
<pageSetUpPr fitToPage="false"/>
</sheetPr>

<dimension ref="1:49"/>

<sheetViews>
<sheetView colorId="64" defaultGridColor="true" rightToLeft="false" showFormulas="false" showGridLines="true" showOutlineSymbols="true" showRowColHeaders="true" showZeros="true">
<selection activeCell="A29" activeCellId="0" pane="topLeft" sqref="A29"/>
</sheetView>
</sheetViews>
<cols>
<col collapsed="false" hidden="false" max="1" min="1" style="0" width="51.9333333333333"/>
<col collapsed="false" hidden="false" max="2" min="2" style="0" width="21.8313725490196"/>
<col collapsed="false" hidden="false" max="3" min="3" style="0" width="22.5647058823529"/>
<col collapsed="false" hidden="false" max="1025" min="4" style="0" width="11.6745098039216"/>
</cols>
```

note that dimension is "1:49", while xlrd expects it to be of the form "A1:D49".

In my patch I add an argument for cell_name_to_rowx_colx, which allows parsing cell names with missing columns, and if we have no information about column range in this file, we just do not set them.

If this is fine, I will add direct tests for cell_name_to_rowx_colx (currently, there are no such direct tests).