### PR TITLE
Add method to get generator for iterating rows.

### DIFF
--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -2,8 +2,9 @@
 
 from unittest import TestCase
 
-import sys
 import os
+import sys
+import types
 import unittest
 
 import xlrd
@@ -91,6 +92,12 @@ class TestSheet(TestCase):
         sheet = self.book.sheet_by_index(SHEETINDEX)
         row = sheet.row(0)
         self.assertEqual(len(row), NCOLS)
+
+    def test_get_rows(self):
+        sheet = self.book.sheet_by_index(SHEETINDEX)
+        rows = sheet.get_rows()
+        self.assertTrue(isinstance(rows, types.GeneratorType), True)
+        self.assertEqual(len(list(rows)), sheet.nrows)
 
     def test_col_slice(self):
         sheet = self.book.sheet_by_index(SHEETINDEX)

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -458,6 +458,11 @@ class Sheet(BaseObject):
             ]
 
     ##
+    # Returns a generator for iterating through each row.
+    def get_rows(self):
+        return (self.row(index) for index in range(self.nrows))
+
+    ##
     # Returns a slice of the types
     # of the cells in the given row.
     def row_types(self, rowx, start_colx=0, end_colx=None):


### PR DESCRIPTION
This will return a generator providing each row in the workbook. This is useful, for instance, when using `map` to map a function to each row.

As a secondary note, shouldn't these comments be docstrings? It'd make this tool a lot easier to use from the shell.