### PR TITLE
NoneType zoom variable causes crash

### DIFF
--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -1532,7 +1532,7 @@ class Sheet(BaseObject):
             else:
                 self.cooked_normal_view_mag_factor = self.scl_mag_factor
             zoom = self.cached_page_break_preview_mag_factor
-            if zoom == 0:
+            if not zoom:
                 # VALID, defaults to 60
                 zoom = 60
             elif not (10 <= zoom <= 400):


### PR DESCRIPTION
I'm working with some old third-party software that outputs its own flavor of .xls. A sample file can be downloaded with:

```
wget https://www.dropbox.com/s/japk6uv4u1js7sz/xlrd_test.XLS 
```

To replicate:

```python
import xlrd
wb = xlrd.open_workbook("xlrd_test.XLS", encoding_override="latin-1", verbosity=1)
```

Stack trace:

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-22e058971f78> in <module>()
----> 1 wb = xlrd.open_workbook("xlrd_test.XLS", encoding_override="latin-1", verbosity=1)

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/__init__.py in open_workbook(filename, logfile, verbosity, use_mmap, file_contents, encoding_override, formatting_info, on_demand, ragged_rows)
    433         formatting_info=formatting_info,
    434         on_demand=on_demand,
--> 435         ragged_rows=ragged_rows,
    436         )
    437     return bk

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/book.py in open_workbook_xls(filename, logfile, verbosity, use_mmap, file_contents, encoding_override, formatting_info, on_demand, ragged_rows)
    105                     "*** Setting on_demand to False.\n")
    106                 bk.on_demand = on_demand = False
--> 107             bk.fake_globals_get_sheet()
    108         elif biff_version == 45:
    109             # worksheet(s) embedded in global stream

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/book.py in fake_globals_get_sheet(self)
    685         self._sheet_visibility = [0] # one sheet, visible
    686         self._sheet_list.append(None) # get_sheet updates _sheet_list but needs a None beforehand
--> 687         self.get_sheets()
    688 
    689     def handle_boundsheet(self, data):

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/book.py in get_sheets(self)
    676         for sheetno in xrange(len(self._sheet_names)):
    677             if DEBUG: print("GET_SHEETS: sheetno =", sheetno, self._sheet_names, self._sh_abs_posn, file=self.logfile)
--> 678             self.get_sheet(sheetno)
    679 
    680     def fake_globals_get_sheet(self): # for BIFF 4.0 and earlier

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/book.py in get_sheet(self, sh_number, update_pos)
    667                 sh_number,
    668                 )
--> 669         sh.read(self)
    670         self._sheet_list[sh_number] = sh
    671         return sh

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/sheet.py in read(self, bk)
   1468                 % (self.number, self.name))
   1469         self.tidy_dimensions()
-> 1470         self.update_cooked_mag_factors()
   1471         bk._position = oldpos
   1472         return 1

/home/patrick/miniconda3/lib/python3.4/site-packages/xlrd/sheet.py in update_cooked_mag_factors(self)
   1536                 # VALID, defaults to 60
   1537                 zoom = 60
-> 1538             elif not (10 <= zoom <= 400):
   1539                 if blah:
   1540                     print((

TypeError: unorderable types: int() <= NoneType()
```

Fixed in this pull request by expanding `zoom == 0` to `not zoom`.