### PR TITLE
Add unicode_errors to open_workbook

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -386,6 +386,7 @@ def open_workbook(filename=None,
     formatting_info=False,
     on_demand=False,
     ragged_rows=False,
+    unicode_errors="strict",
     ):
     peeksz = 4
     if file_contents:
@@ -433,6 +434,7 @@ def open_workbook(filename=None,
         formatting_info=formatting_info,
         on_demand=on_demand,
         ragged_rows=ragged_rows,
+        unicode_errors=unicode_errors,
         )
     return bk
 

--- a/xlrd/formatting.py
+++ b/xlrd/formatting.py
@@ -28,8 +28,8 @@ _cellty_from_fmtty = {
     FGE: XL_CELL_NUMBER,
     FDT: XL_CELL_DATE,
     FTX: XL_CELL_NUMBER, # Yes, a number can be formatted as text.
-    }    
-    
+    }
+
 excel_default_palette_b5 = (
     (  0,   0,   0), (255, 255, 255), (255,   0,   0), (  0, 255,   0),
     (  0,   0, 255), (255, 255,   0), (255,   0, 255), (  0, 255, 255),
@@ -277,9 +277,9 @@ def handle_font(book, data):
         f.outline = (option_flags & 16) >> 4
         f.shadow = (option_flags & 32) >> 5
         if bv >= 80:
-            f.name = unpack_unicode(data, 14, lenlen=1)
+            f.name = unpack_unicode(data, 14, book.unicode_errors, lenlen=1)
         else:
-            f.name = unpack_string(data, 14, book.encoding, lenlen=1)
+            f.name = unpack_string(data, 14, book.encoding, book.unicode_errors, lenlen=1)
     elif bv >= 30:
         f.height, option_flags, f.colour_index = unpack('<HHH', data[0:6])
         f.bold = option_flags & 1
@@ -288,7 +288,7 @@ def handle_font(book, data):
         f.struck_out = (option_flags & 8) >> 3
         f.outline = (option_flags & 16) >> 4
         f.shadow = (option_flags & 32) >> 5
-        f.name = unpack_string(data, 6, book.encoding, lenlen=1)
+        f.name = unpack_string(data, 6, book.encoding, book.unicode_errors, lenlen=1)
         # Now cook up the remaining attributes ...
         f.weight = [400, 700][f.bold]
         f.escapement = 0 # None
@@ -304,7 +304,7 @@ def handle_font(book, data):
         f.struck_out = (option_flags & 8) >> 3
         f.outline = 0
         f.shadow = 0
-        f.name = unpack_string(data, 4, book.encoding, lenlen=1)
+        f.name = unpack_string(data, 4, book.encoding, book.unicode_errors, lenlen=1)
         # Now cook up the remaining attributes ...
         f.weight = [400, 700][f.bold]
         f.escapement = 0 # None
@@ -456,7 +456,7 @@ def is_date_format_string(book, fmt):
     # TODO: u'[h]\\ \\h\\o\\u\\r\\s' ([h] means don't care about hours > 23)
     state = 0
     s = ''
-    
+
     for c in fmt:
         if state == 0:
             if c == UNICODE_LITERAL('"'):
@@ -523,9 +523,9 @@ def handle_format(self, data, rectype=XL_FORMAT):
             strpos = 0
     self.actualfmtcount += 1
     if bv >= 80:
-        unistrg = unpack_unicode(data, 2)
+        unistrg = unpack_unicode(data, 2, self.unicode_errors)
     else:
-        unistrg = unpack_string(data, strpos, self.encoding, lenlen=1)
+        unistrg = unpack_string(data, strpos, self.encoding, self.unicode_errors, lenlen=1)
     blah = DEBUG or self.verbosity >= 3
     if blah:
         fprintf(self.logfile,
@@ -645,7 +645,7 @@ def handle_style(book, data):
         level = 0
         if bv >= 80:
             try:
-                name = unpack_unicode(data, 2, lenlen=2)
+                name = unpack_unicode(data, 2, book.unicode_errors, lenlen=2)
             except UnicodeDecodeError:
                 print("STYLE: built_in=%d xf_index=%d built_in_id=%d level=%d" \
                     % (built_in, xf_index, built_in_id, level), file=book.logfile)
@@ -1009,7 +1009,7 @@ def xf_epilogue(self):
                 elif not self.xf_list[xf.parent_style_index].is_style:
                     fprintf(self.logfile,
                         "NOTE !!! XF[%d]: parent_style_index is %d; style flag not set\n",
-                        xf.xf_index, xf.parent_style_index)                
+                        xf.xf_index, xf.parent_style_index)
             if blah1 and xf.parent_style_index > xf.xf_index:
                 fprintf(self.logfile,
                     "NOTE !!! XF[%d]: parent_style_index is %d; out of order?\n",

--- a/xlrd/formula.py
+++ b/xlrd/formula.py
@@ -10,7 +10,7 @@
 
 # No part of the content of this file was derived from the works of David Giffin.
 
-from __future__ import print_function 
+from __future__ import print_function
 import copy
 from struct import unpack
 from .timemachine import *
@@ -968,10 +968,10 @@ def evaluate_name_formula(bk, nobj, namex, blah=0, level=0):
             elif opcode == 0x17: # tStr
                 if bv <= 70:
                     strg, newpos = unpack_string_update_pos(
-                                        data, pos+1, bk.encoding, lenlen=1)
+                                        data, pos+1, bk.encoding, bk.unicode_errors, lenlen=1)
                 else:
                     strg, newpos = unpack_unicode_update_pos(
-                                        data, pos+1, lenlen=1)
+                                        data, pos+1, bk.unicode_errors, lenlen=1)
                 sz = newpos - pos
                 if blah: print("   sz=%d strg=%r" % (sz, strg), file=bk.logfile)
                 text = '"' + strg.replace('"', '""') + '"'
@@ -1541,10 +1541,10 @@ def decompile_formula(bk, fmla, fmlalen,
             elif opcode == 0x17: # tStr
                 if bv <= 70:
                     strg, newpos = unpack_string_update_pos(
-                                        data, pos+1, bk.encoding, lenlen=1)
+                                        data, pos+1, bk.encoding, bk.unicode_errors, lenlen=1)
                 else:
                     strg, newpos = unpack_unicode_update_pos(
-                                        data, pos+1, lenlen=1)
+                                        data, pos+1, bk.unicode_errors, lenlen=1)
                 sz = newpos - pos
                 if blah: print("   sz=%d strg=%r" % (sz, strg), file=bk.logfile)
                 text = '"' + strg.replace('"', '""') + '"'
@@ -1943,7 +1943,7 @@ def dump_formula(bk, data, fmlalen, bv, reldelta, blah=0, isname=0):
                     strg = data[pos+2:pos+2+nc] # left in 8-bit encoding
                     sz = nc + 2
                 else:
-                    strg, newpos = unpack_unicode_update_pos(data, pos+1, lenlen=1)
+                    strg, newpos = unpack_unicode_update_pos(data, pos+1, bk.unicode_errors, lenlen=1)
                     sz = newpos - pos
                 if blah: print("   sz=%d strg=%r" % (sz, strg), file=bk.logfile)
             else:

--- a/xlrd/timemachine.py
+++ b/xlrd/timemachine.py
@@ -23,11 +23,12 @@ if python_version >= (3, 0):
         if fmt.endswith('\n'):
             print(fmt[:-1] % vargs, file=f)
         else:
-            print(fmt % vargs, end=' ', file=f)        
+            print(fmt % vargs, end=' ', file=f)
     EXCEL_TEXT_TYPES = (str, bytes, bytearray) # xlwt: isinstance(obj, EXCEL_TEXT_TYPES)
     REPR = ascii
     xrange = range
-    unicode = lambda b, enc: b.decode(enc)
+    def unicode(b, enc, errors="strict"):
+        return b.decode(enc, errors=errors)
     ensure_unicode = lambda s: s
     unichr = chr
 else:
@@ -40,7 +41,7 @@ else:
         if fmt.endswith('\n'):
             print(fmt[:-1] % vargs, file=f)
         else:
-            print(fmt % vargs, end=' ', file=f)        
+            print(fmt % vargs, end=' ', file=f)
     try:
         EXCEL_TEXT_TYPES = basestring # xlwt: isinstance(obj, EXCEL_TEXT_TYPES)
     except NameError:
@@ -49,4 +50,4 @@ else:
     xrange = xrange
     # following used only to overcome 2.x ElementTree gimmick which
     # returns text as `str` if it's ascii, otherwise `unicode`
-    ensure_unicode = unicode # used only in xlsx.py 
+    ensure_unicode = unicode # used only in xlsx.py


### PR DESCRIPTION
Can be any allowed Python error handler (eg "strict", "ignore", "replace")

This is issue #126 
I've taken a bit of a shotgun approach here... I'm not 100% convinced every usage of unicode() that I've added the configurable error handler to is necessary, but all tests do pass.