### PR TITLE
Update supported pythons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Version of xlrd**: 0.7.1 -- 2009-05-31
 
-**Versions of Python supported**: 2.6-2.7.
+**Versions of Python supported**: 2.6, 2.7, 3.2+.
 
 **External modules required**:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-
+envlist = py26, py27, py32, py33, py34
 [testenv]
 deps=
   nose


### PR DESCRIPTION
The README had an outdated list of supported python version. Tox.ini didn't have an envlist at all.

I used the versions listed in .travis.yaml for both.
