### PR TITLE
Fix xlsx sheet -> comments relationship in version 0.9.4, issue #108. 

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -793,12 +793,16 @@ def open_workbook_2007_xml(
         heading = "Sheet %r (sheetx=%d) from %r" % (sheet.name, sheetx, fname)
         x12sheet.process_stream(zflo, heading)
         del zflo
-        comments_fname = 'xl/comments%d.xml' % (sheetx + 1)
-        if comments_fname in component_names:
-            comments_stream = zf.open(component_names[comments_fname])
-            x12sheet.process_comments_stream(comments_stream)
-            del comments_stream
-
+        rel_name = 'xl/worksheets/_rels/sheet%d.xml.rels' % (sheetx + 1)
+        if rel_name in  component_names:
+            comments_rel = zf.open(component_names[rel_name])
+            for rel in  ET.parse(comments_rel).getroot():
+                find_comment = re.search('comments[0-9]+.xml',rel.attrib['Target'])
+                if find_comment:
+                    comments_fname = "xl/" +  find_comment.group(0)
+                    comments_stream = zf.open(component_names[comments_fname])
+                    x12sheet.process_comments_stream(comments_stream)
+                    del comments_stream
         sheet.tidy_dimensions()
 
     return bk


### PR DESCRIPTION
There is an issue with sheet-comments relationship in `xlrd 0.9.4`. This issue happens in function `open_workbook_2007_xml` in `xlsx.py`. 

Basically, `open_workbook_2007_xml` assigns the comments in file `xl/commentsN.xml` to `xl/worksheets/sheetN.xml`. However, Excel defines the relationship between `sheetN` and its comments in file `xl/worksheets/_rels/sheetN.xml.rels`, in an `xml` object attribute called `Target`. Not by the naming convention `sheetN.xml ==> commentsN.xml`. 

For example, if there are 5 sheets and 2 of them have some comments, Excel would generate two comments files `xl/comments1.xml` and `xl/comments2.xml` disregarding in which sheet they appear. If `SheetX.xml` is related to the comments in `xl/comments1.xml`, then in `xl/worksheets/_rels/sheetX.xml.rels` you'll find the attribute `Target=../comments1.xml`.

To fix the issue this patch reads the attributes of the files in `xl/worksheets/_rels/` and assign the comments to the proper sheets. Fix is tested on Windows 8.1.

This would fix issue #108. 
