### PR TITLE
Fix unequal row lengths.

### DIFF
--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -8,6 +8,7 @@ import types
 import unittest
 
 import xlrd
+from xlrd.timemachine import xrange
 
 from .base import from_this_dir
 
@@ -17,6 +18,7 @@ NCOLS = 13
 
 ROW_ERR = NROWS + 10
 COL_ERR = NCOLS + 10
+
 
 class TestSheet(TestCase):
 
@@ -123,6 +125,7 @@ class TestSheet(TestCase):
         sheet = self.book.sheet_by_index(SHEETINDEX)
         self.check_col_slice(sheet.row_values)
 
+
 class TestSheetRagged(TestCase):
     
     def test_read_ragged(self):
@@ -133,3 +136,12 @@ class TestSheetRagged(TestCase):
         self.assertEqual(sheet.row_len(2), 1)
         self.assertEqual(sheet.row_len(3), 4)
         self.assertEqual(sheet.row_len(4), 4)
+
+
+class TestMergedCells(TestCase):
+
+    def test_tidy_dimensions(self):
+        book = xlrd.open_workbook(from_this_dir('merged_cells.xlsx'))
+        for sheet in book.sheets():
+            for rowx in xrange(sheet.nrows):
+                self.assertEqual(sheet.row_len(rowx), sheet.ncols)

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -577,6 +577,7 @@ class Sheet(BaseObject):
                 if chi > nc: nc = chi
             if nc > self.ncols:
                 self.ncols = nc
+                self._first_full_rowx = -2
             if nr > self.nrows:
                 # we put one empty cell at (nr-1,0) to make sure
                 # we have the right number of rows. The ragged rows


### PR DESCRIPTION
Fixes a bug for ragged_rows=False when merged cells increases the number of columns in the sheet. This requires all rows to be extended to ensure equal row lengths that match the number of columns in the sheet.

Resolves issues #113 and #129.