### PR TITLE
Make unicode parsing more forgiving.

### DIFF
--- a/xlrd/biffh.py
+++ b/xlrd/biffh.py
@@ -348,10 +348,10 @@ def unpack_unicode_update_pos(data, pos, lenlen=2, known_len=None):
     if options & 0x01:
         # Uncompressed UTF-16-LE
         try:
-            strg = unicode(rawstrg, 'utf_16_le')
+            strg = unicode(data[pos:pos+2*nchars], 'utf_16_le')
         except UnicodeDecodeError as e:
-            if e.end == len(rawstrg):
-                strg = unicode(rawstrg[:-1] + b'\0', 'utf_16_le')
+            if e.end == 2*nchars:
+                strg = unicode(data[pos:pos+2*nchars-1] + b'\0', 'utf_16_le')
             else:
                 raise
         pos += 2*nchars


### PR DESCRIPTION
If while attempting to parse UTF-16-LE text an error occurs at the final byte of the input, replace that byte with a NUL (i.e., project the final sixteen bits to the Latin-1 plane) and retry.

This PR is quite focused, but I'm still not sure it's a good idea.

Pros:
- allows `xlrd` to read malformed files encountered in the wild
- never changes the parsing of valid input
- is unlikely to mask errors other than the particular error it addresses

Cons:
- +13 SLOC
- "be strict in what you emit and liberal in what you accept" is a load of bullfeathers
- continuing to parse data after it has been found to be malformed may have security implications

An example error follows. Note that the error string consists entirely of ascii characters, except for the last code point, which projects to an ascii character when the high byte is set to NUL.
```python
In [1]: import xlrd

In [2]: %pdb on
Automatic pdb calling has been turned ON

In [3]: xlrd.open_workbook('0008 Turbofit Data_cleaned.xls')
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-3-0f08b2429777> in <module>()
----> 1 xlrd.open_workbook('0008 Turbofit Data_cleaned.xls')

/Users/afni/homebrew/lib/python2.7/site-packages/xlrd/__init__.pyc in open_workbook(filename, logfile, verbosity, use_mmap, file_contents, encoding_override, formatting_info, on_demand, ragged_rows)
    433         formatting_info=formatting_info,
    434         on_demand=on_demand,
--> 435         ragged_rows=ragged_rows,
    436         )
    437     return bk

/Users/afni/homebrew/lib/python2.7/site-packages/xlrd/book.pyc in open_workbook_xls(filename, logfile, verbosity, use_mmap, file_contents, encoding_override, formatting_info, on_demand, ragged_rows)
    114                 bk.on_demand = on_demand = False
    115         else:
--> 116             bk.parse_globals()
    117             bk._sheet_list = [None for sh in bk._sheet_names]
    118             if not on_demand:

/Users/afni/homebrew/lib/python2.7/site-packages/xlrd/book.pyc in parse_globals(self)
   1160                 self.handle_font(data)
   1161             elif rc == XL_FORMAT: # XL_FORMAT2 is BIFF <= 3.0, can't appear in globals
-> 1162                 self.handle_format(data)
   1163             elif rc == XL_XF:
   1164                 self.handle_xf(data)

/Users/afni/homebrew/lib/python2.7/site-packages/xlrd/formatting.pyc in handle_format(self, data, rectype)
    524     self.actualfmtcount += 1
    525     if bv >= 80:
--> 526         unistrg = unpack_unicode(data, 2)
    527     else:
    528         unistrg = unpack_string(data, strpos, self.encoding, lenlen=1)

/Users/afni/homebrew/lib/python2.7/site-packages/xlrd/biffh.pyc in unpack_unicode(data, pos, lenlen)
    301         rawstrg = data[pos:pos+2*nchars]
    302         # if DEBUG: print "nchars=%d pos=%d rawstrg=%r" % (nchars, pos, rawstrg)
--> 303         strg = unicode(rawstrg, 'utf_16_le')
    304         # pos += 2*nchars
    305     else:

/Users/afni/homebrew/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/encodings/utf_16_le.pyc in decode(input, errors)
     14 
     15 def decode(input, errors='strict'):
---> 16     return codecs.utf_16_le_decode(input, errors, True)
     17 
     18 class IncrementalEncoder(codecs.IncrementalEncoder):

UnicodeDecodeError: 'utf16' codec can't decode bytes in position 80-81: unexpected end of data
> /Users/afni/homebrew/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/encodings/utf_16_le.py(16)decode()
     15 def decode(input, errors='strict'):
---> 16     return codecs.utf_16_le_decode(input, errors, True)
     17 

ipdb> u
> /Users/afni/homebrew/lib/python2.7/site-packages/xlrd/biffh.py(303)unpack_unicode()
    302         # if DEBUG: print "nchars=%d pos=%d rawstrg=%r" % (nchars, pos, rawstrg)
--> 303         strg = unicode(rawstrg, 'utf_16_le')
    304         # pos += 2*nchars

ipdb> p rawstrg
'_\x00(\x00*\x00 \x00#\x00,\x00#\x00#\x000\x00_\x00)\x00;\x00_\x00(\x00*\x00 \x00\\\x00(\x00#\x00,\x00#\x00#\x000\x00\\\x00)\x00;\x00_\x00(\x00*\x00 \x00"\x00-\x00"\x00_\x00)\x00;\x00_\x00(\x00@\x00_\x00)\xd8'
ipdb> p rawstrg[::2]
'_(* #,##0_);_(* \\(#,##0\\);_(* "-"_);_(@_)'
ipdb> p rawstrg[1::2]
'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd8'
```