### PR TITLE
Uniform empty cell value (always unicode string) for Python2 and Python3 #159

### DIFF
--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import xlrd
+from xlrd.timemachine import UNICODE_LITERAL
 
 from .base import from_this_dir
 
@@ -19,12 +20,14 @@ class TestCell(unittest.TestCase):
         cell = sheet.cell(0, 0)
         self.assertEqual(cell.ctype, xlrd.book.XL_CELL_EMPTY)
         self.assertEqual(cell.value, '')
+        self.assertEqual(type(cell.value), type(''))
         self.assertTrue(cell.xf_index > 0)
 
     def test_string_cell(self):
         cell = self.sheet.cell(0, 0)
         self.assertEqual(cell.ctype, xlrd.book.XL_CELL_TEXT)
         self.assertEqual(cell.value, 'PROFIL')
+        self.assertEqual(type(cell.value), type(UNICODE_LITERAL('')))
         self.assertTrue(cell.xf_index > 0)
 
     def test_number_cell(self):

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -20,7 +20,7 @@ class TestCell(unittest.TestCase):
         cell = sheet.cell(0, 0)
         self.assertEqual(cell.ctype, xlrd.book.XL_CELL_EMPTY)
         self.assertEqual(cell.value, '')
-        self.assertEqual(type(cell.value), type(''))
+        self.assertEqual(type(cell.value), type(UNICODE_LITERAL('')))
         self.assertTrue(cell.xf_index > 0)
 
     def test_string_cell(self):

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -582,7 +582,7 @@ class Sheet(BaseObject):
                 # we put one empty cell at (nr-1,0) to make sure
                 # we have the right number of rows. The ragged rows
                 # will sort out the rest if needed.
-                self.put_cell(nr-1, 0, XL_CELL_EMPTY, '', -1)
+                self.put_cell(nr-1, 0, XL_CELL_EMPTY, UNICODE_LITERAL(''), -1)
         if self.verbosity >= 1 \
         and (self.nrows != self._dimnrows or self.ncols != self._dimncols):
             fprintf(self.logfile,
@@ -611,7 +611,7 @@ class Sheet(BaseObject):
                 rlen = len(trow)
                 nextra = ncols - rlen
                 if nextra > 0:
-                    s_cell_values[rowx][rlen:] = [''] * nextra
+                    s_cell_values[rowx][rlen:] = [UNICODE_LITERAL('')] * nextra
                     trow[rlen:] = self.bt * nextra
                     if s_fmt_info:
                         s_cell_xf_indexes[rowx][rlen:] = self.bf * nextra
@@ -660,11 +660,11 @@ class Sheet(BaseObject):
                 num_empty += 1
                 # self._put_cell_row_widenings += 1
                 # types_row.extend(self.bt * num_empty)
-                # values_row.extend([''] * num_empty)
+                # values_row.extend([UNICODE_LITERAL('')] * num_empty)
                 # if fmt_info:
                 #     fmt_row.extend(self.bf * num_empty)
                 types_row[ltr:] = self.bt * num_empty
-                values_row[ltr:] = [''] * num_empty
+                values_row[ltr:] = [UNICODE_LITERAL('')] * num_empty
                 if fmt_info:
                     fmt_row[ltr:] = self.bf * num_empty
             types_row[colx] = ctype
@@ -718,7 +718,7 @@ class Sheet(BaseObject):
                     trow.extend(self.bt * nextra)
                     if self.formatting_info:
                         self._cell_xf_indexes[rowx].extend(self.bf * nextra)
-                    self._cell_values[rowx].extend([''] * nextra)
+                    self._cell_values[rowx].extend([UNICODE_LITERAL('')] * nextra)
             else:
                 scta = self._cell_types.append
                 scva = self._cell_values.append
@@ -730,7 +730,7 @@ class Sheet(BaseObject):
                 for _unused in xrange(self.nrows, nr):
                     # self._put_cell_rows_appended += 1
                     scta(bt * nc)
-                    scva([''] * nc)
+                    scva([UNICODE_LITERAL('')] * nc)
                     if fmt_info:
                         scxa(bf * nc)
                 self.nrows = nr
@@ -2266,7 +2266,7 @@ class Cell(BaseObject):
 ##
 # There is one and only one instance of an empty cell -- it's a singleton. This is it.
 # You may use a test like "acell is empty_cell".
-empty_cell = Cell(XL_CELL_EMPTY, '')
+empty_cell = Cell(XL_CELL_EMPTY, UNICODE_LITERAL(''))
 
 ##### =============== Colinfo and Rowinfo ============================== #####
 


### PR DESCRIPTION
Current situation: Empty cell value is a bytestring on Python2 and a
unicode string on Python3.