### PR TITLE
This allows xlrd to be made into a wheel file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ av = sys.argv
 if len(av) > 1 and av[1].lower() == "--egg":
     del av[1]
     from setuptools import setup
+if len(av) > 1 and av[1].lower() == "bdist_wheel":
+    from setuptools import setup
 else:
     from distutils.core import setup
 


### PR DESCRIPTION
This change allows xlrd to be made into a wheel file. using the following command
python setup.py bdist_wheel

This seems to be the standard format for python packaging going forward so something that we should have support for.