### PR TITLE
Update changes.rst to fix a typo in method name

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -89,7 +89,7 @@ Thanks to the following for their contributions to this release:
 
 - Read cell comments in .xlsx files.
 
-- Added xldate_to_datetime() function to convert from Excel
+- Added xldate_as_datetime() function to convert from Excel
   serial date/time to datetime.datetime object.
 
 Thanks to the following for their contributions to this release:


### PR DESCRIPTION
`xldate_to_datetime()` does not exist: it is named `xldate_as_datetime` in the xldate.py file.

I lost 5min to search for the function by name, so it might be useful for anyone else :-)