### PR TITLE
Avoid raising exception when WRITEACCESS record can't be decoded

### DIFF
--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -1186,7 +1186,7 @@ class Book(BaseObject):
             try:
                 strg = unpack_unicode(data, 0, lenlen=2)
             except:
-                strg = ""
+                strg = UNICODE_LITERAL("")
         if DEBUG: fprintf(self.logfile, "WRITEACCESS: %d bytes; raw=%s %r\n", len(data), self.raw_user_name, strg)
         strg = strg.rstrip()
         self.user_name = strg

--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -1183,7 +1183,10 @@ class Book(BaseObject):
                 return
             strg = unpack_string(data, 0, self.encoding, lenlen=1)
         else:
-            strg = unpack_unicode(data, 0, lenlen=2)
+            try:
+                strg = unpack_unicode(data, 0, lenlen=2)
+            except:
+                strg = ""
         if DEBUG: fprintf(self.logfile, "WRITEACCESS: %d bytes; raw=%s %r\n", len(data), self.raw_user_name, strg)
         strg = strg.rstrip()
         self.user_name = strg


### PR DESCRIPTION
Based off the below stack overflow answer. would like to be part of the release
http://stackoverflow.com/questions/28334966/encoding-error-when-opening-an-excel-file-with-xlrd