### PR TITLE
Upgrade setuptools prior to installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ python:
   - "2.7"
   - "2.6"
 
-# command to install dependencies
-install: "pip install -Ur requirements.txt"
+install:
+# upgrade setuptools separately to avoid race condition
+- pip install -U setuptools
+# install dependencies
+- pip install -Ur requirements.txt
 
 # command to run tests, e.g. python setup.py test
 script: nosetests --with-cov --cov=xlrd


### PR DESCRIPTION
Avoids issues where setuptools isn't in a viable state during build of other packages.