### PR TITLE
Update compdoc.py for 'xff\xfe'

### DIFF
--- a/xlrd/compdoc.py
+++ b/xlrd/compdoc.py
@@ -84,7 +84,7 @@ class CompDoc(object):
         self.DEBUG = DEBUG
         if mem[0:8] != SIGNATURE:
             raise CompDocError('Not an OLE2 compound document')
-        if mem[28:30] != b'\xFE\xFF':
+        if mem[28:30] != b'\xFE\xFF' & mem[28:30] != b'\xff\xfe':
             raise CompDocError('Expected "little-endian" marker, found %r' % mem[28:30])
         revision, version = unpack('<HH', mem[24:28])
         if DEBUG:

--- a/xlrd/compdoc.py
+++ b/xlrd/compdoc.py
@@ -84,7 +84,7 @@ class CompDoc(object):
         self.DEBUG = DEBUG
         if mem[0:8] != SIGNATURE:
             raise CompDocError('Not an OLE2 compound document')
-        if mem[28:30] != b'\xFE\xFF' & mem[28:30] != b'\xff\xfe':
+        if mem[28:30] != b'\xFE\xFF' and mem[28:30] != b'\xff\xfe':
             raise CompDocError('Expected "little-endian" marker, found %r' % mem[28:30])
         revision, version = unpack('<HH', mem[24:28])
         if DEBUG:


### PR DESCRIPTION
updating compdoc.py to accommodate other mem types 'xff\xfe'

I received the following error:
File "/usr/local/lib/python2.7/dist-packages/xlrd/compdoc.py", line 91, in __init__
    raise CompDocError('Expected "little-endian" marker, found %r' % mem[28:30])
xlrd.compdoc.CompDocError: Expected "little-endian" marker, found '\xff\xfe' 