### PR TITLE
Fix IronPython with russian Letters

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -43,7 +43,10 @@ def ensure_elementtree_imported(verbosity, logfile):
                         except ImportError:
                             raise Exception("Failed to import an ElementTree implementation")
     if hasattr(ET, 'iterparse'):
-        _dummy_stream = BYTES_IO(b'')
+        if 'IronPython' in sys.version:
+            _dummy_stream = BYTES_IO('')
+        else:
+            _dummy_stream = BYTES_IO(b'')
         try:
             ET.iterparse(_dummy_stream)
             ET_has_iterparse = True
@@ -140,7 +143,11 @@ def cooked_text(self, elem):
         return ''
     if elem.get(XML_SPACE_ATTR) != 'preserve':
         t = t.strip(XML_WHITESPACE)
-    return ensure_unicode(unescape(t))
+    unsc = unescape(t)
+    if 'IronPython'  in sys.version:
+        return (unsc.decode('utf-8'))
+    else:
+        return ensure_unicode(unsc)
 
 def get_text_from_si_or_is(self, elem, r_tag=U_SSML12+'r', t_tag=U_SSML12 +'t'):
     "Returns unescaped unicode"
@@ -483,7 +490,11 @@ class X12Styles(X12General):
         self.xf_type = 1
 
     def do_numfmt(self, elem):
-        formatCode = ensure_unicode(elem.get('formatCode'))
+        el_get = elem.get('formatCode')
+        if 'IronPython' in sys.version:
+            formatCode = (el_get.decode('utf-8'))
+        else:
+            formatCode = ensure_unicode(el_get)
         numFmtId = int(elem.get('numFmtId'))
         is_date = is_date_format_string(self.bk, formatCode)
         self.fmt_is_date[numFmtId] = is_date


### PR DESCRIPTION
Fix IronPython with russian Letters
-
To Start xlrd from IronPython with russian language: https://goo.gl/P7C9zf
Need to fix xmllib at 95 line. Change __accept_utf8 = 0 to 1 : https://goo.gl/y3vZTV