### PR TITLE
Update __init__.py

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -87,6 +87,9 @@ def open_workbook(filename=None,
       When ``True``, formatting information will be read from the spreadsheet
       file. This provides all cells, including empty and blank cells.
       Formatting information is available for each cell.
+      
+      Note that this will raise a NotImplementedError when used with an
+      xlsx file.
 
     :param on_demand:
 


### PR DESCRIPTION
Added warning to the the description for the open_workbook formatting_info parameter, as this will throw an error if used with an xlsx file.