### PR TITLE
Trim trialing white space throughout the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ MANIFEST
 .Python
 /include
 /lib
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "2.7"
 
 # command to install dependencies
-install: 
+install:
 - "pip install -U pip setuptools"
 - "pip install -Ur requirements.txt"
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -543,4 +543,3 @@ Thanks to the following for their contributions to this release:
 -------------------
 
 - first public release
-

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -36,4 +36,3 @@ source of information on how the :class:`Name` attributes hang together.
 
   Name information is *not* extracted from files older than
   Excel 5.0 (``Book.biff_version < 50``).
-

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@
 envlist = py36, py35, py34, py33, py27, py26
 
 [testenv]
-commands = 
+commands =
     pip install -Ur requirements.txt
     nosetests --with-cov --cov=xlrd
-        

--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -87,7 +87,7 @@ def open_workbook(filename=None,
       When ``True``, formatting information will be read from the spreadsheet
       file. This provides all cells, including empty and blank cells.
       Formatting information is available for each cell.
-      
+
       Note that this will raise a NotImplementedError when used with an
       xlsx file.
 


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.