### PR TITLE
Run Travis CI through tox configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,25 @@ cache: pip
 
 language: python
 
-python:
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
+matrix:
+  include:
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "2.7"
+      env: TOXENV=py27
 
-# command to install dependencies
 install:
-- "pip install -U pip setuptools"
-- "pip install -Ur requirements.txt"
+  - pip install tox
 
-# command to run tests, e.g. python setup.py test
-script: nosetests --with-cov --cov=xlrd
+script:
+  - tox
 
 after_success:
+  - pip install coveralls
   - coveralls
 
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 nose
 nose_fixes
 nose-cov
-coveralls
 tox
 # for docs
 sphinx


### PR DESCRIPTION
Removes duplication of testing environments. Testing locally with tox now better matches the Travis CI environment.