### PR TITLE
Use Unicode literals throughout project; drop u str prefix

### DIFF
--- a/xlrd/compdoc.py
+++ b/xlrd/compdoc.py
@@ -354,7 +354,7 @@ class CompDoc(object):
         string if found, otherwise return ``None``.
 
         :param qname:
-          Name of the desired stream e.g. ``u'Workbook'``.
+          Name of the desired stream e.g. ``'Workbook'``.
           Should be in Unicode or convertible thereto.
         """
         d = self._dir_search(qname.split("/"))
@@ -383,7 +383,7 @@ class CompDoc(object):
         ``(new_string, 0, length_of_stream)`` is returned.
 
         :param qname:
-          Name of the desired stream e.g. ``u'Workbook'``.
+          Name of the desired stream e.g. ``'Workbook'``.
           Should be in Unicode or convertible thereto.
         """
         d = self._dir_search(qname.split("/"))

--- a/xlrd/formatting.py
+++ b/xlrd/formatting.py
@@ -222,7 +222,7 @@ class Font(BaseObject, EqNeAttrs):
     #: 1 = Characters are italic.
     italic = 0
 
-    #: The name of the font. Example: ``u"Arial"``.
+    #: The name of the font. Example: ``"Arial"``.
     name = UNICODE_LITERAL("")
 
     #: 1 = Characters are struck out.
@@ -450,9 +450,9 @@ non_date_formats = {
 fmt_bracketed_sub = re.compile(r'\[[^]]*\]').sub
 
 # Boolean format strings (actual cases)
-# u'"Yes";"Yes";"No"'
-# u'"True";"True";"False"'
-# u'"On";"On";"Off"'
+# '"Yes";"Yes";"No"'
+# '"True";"True";"False"'
+# '"On";"On";"Off"'
 
 def is_date_format_string(book, fmt):
     # Heuristics:
@@ -461,9 +461,9 @@ def is_date_format_string(book, fmt):
     # E.g. hh\hmm\mss\s should produce a display like 23h59m59s
     # Date formats have one or more of ymdhs (caseless) in them.
     # Numeric formats have # and 0.
-    # N.B. u'General"."' hence get rid of "text" first.
+    # N.B. 'General"."' hence get rid of "text" first.
     # TODO: Find where formats are interpreted in Gnumeric
-    # TODO: u'[h]\\ \\h\\o\\u\\r\\s' ([h] means don't care about hours > 23)
+    # TODO: '[h]\\ \\h\\o\\u\\r\\s' ([h] means don't care about hours > 23)
     state = 0
     s = ''
 

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -2250,7 +2250,7 @@ class Cell(BaseObject):
         <tr>
         <td>XL_CELL_EMPTY</td>
         <td align="center">0</td>
-        <td>empty string u''</td>
+        <td>empty string ''</td>
         </tr>
         <tr>
         <td>XL_CELL_TEXT</td>
@@ -2281,7 +2281,7 @@ class Cell(BaseObject):
         <tr>
         <td>XL_CELL_BLANK</td>
         <td align="center">6</td>
-        <td>empty string u''. Note: this type will appear only when
+        <td>empty string ''. Note: this type will appear only when
         open_workbook(..., formatting_info=True) is used.</td>
         </tr>
         </table>


### PR DESCRIPTION
More forward compatible with modern Python 3 syntax.