### PR TITLE
Use replacement marker for poorly packed unicode string

### DIFF
--- a/xlrd/biffh.py
+++ b/xlrd/biffh.py
@@ -281,7 +281,7 @@ def unpack_unicode(data, pos, lenlen=2):
         # Uncompressed UTF-16-LE
         rawstrg = data[pos:pos+2*nchars]
         # if DEBUG: print "nchars=%d pos=%d rawstrg=%r" % (nchars, pos, rawstrg)
-        strg = unicode(rawstrg, 'utf_16_le')
+        strg = unicode(rawstrg, 'utf_16_le', 'replace')
         # pos += 2*nchars
     else:
         # Note: this is COMPRESSED (not ASCII!) encoding!!!
@@ -321,7 +321,7 @@ def unpack_unicode_update_pos(data, pos, lenlen=2, known_len=None):
         pos += 4
     if options & 0x01:
         # Uncompressed UTF-16-LE
-        strg = unicode(data[pos:pos+2*nchars], 'utf_16_le')
+        strg = unicode(data[pos:pos+2*nchars], 'utf_16_le', 'replace')
         pos += 2*nchars
     else:
         # Note: this is COMPRESSED (not ASCII!) encoding!!!

--- a/xlrd/timemachine.py
+++ b/xlrd/timemachine.py
@@ -28,7 +28,7 @@ if python_version >= (3, 0):
     EXCEL_TEXT_TYPES = (str, bytes, bytearray) # xlwt: isinstance(obj, EXCEL_TEXT_TYPES)
     REPR = ascii
     xrange = range
-    unicode = lambda b, enc: b.decode(enc)
+    unicode = lambda b, enc, errors='strict': b.decode(enc, errors=errors)
     ensure_unicode = lambda s: s
     unichr = chr
 else:


### PR DESCRIPTION
This PR will change the behavior of unpacking poorly packed unicode strings.

It will replace corrupted bytes into `U+FFFD` (REPLACEMENT CHARACTER) instead of raising error, so that the whole parsing process can be unaffected by workbook's trivial or local errors.