### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/docs/vulnerabilities.rst
+++ b/docs/vulnerabilities.rst
@@ -37,7 +37,7 @@ to those later in the list:
 To guard against these problems, you should consider the `defusedxml`__
 project which can be used as follows:
 
-__ https://pypi.python.org/pypi/defusedxml/
+__ https://pypi.org/project/defusedxml/
 
 .. code-block:: python
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html