### PR TITLE
Make `Sheet` and `Book` more Pythonic and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
 
 after_success:
   - if [ $TOXENV != lint ]; then pip install coveralls; fi
+  - if [ $TOXENV == py27 ]; then pip install requests --upgrade; fi
   - if [ $TOXENV != lint ]; then coveralls; fi
 
 deploy:

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -91,11 +91,37 @@ class TestSheet(TestCase):
         row = sheet.row(0)
         self.assertEqual(len(row), NCOLS)
 
+    def test_getitem_int(self):
+        sheet = self.book.sheet_by_index(SHEETINDEX)
+        row = sheet[0]
+        self.assertEqual(len(row), NCOLS)
+
+    def test_getitem_tuple(self):
+        sheet = self.book.sheet_by_index(SHEETINDEX)
+        self.assertNotEqual(xlrd.empty_cell, sheet[0, 0])
+        self.assertNotEqual(xlrd.empty_cell, sheet[NROWS-1, NCOLS-1])
+
+    def test_getitem_failure(self):
+        sheet = self.book.sheet_by_index(SHEETINDEX)
+        with self.assertRaises(ValueError):
+            sheet[0, 0, 0]
+
+        with self.assertRaises(TypeError):
+            sheet["hi"]
+
     def test_get_rows(self):
         sheet = self.book.sheet_by_index(SHEETINDEX)
         rows = sheet.get_rows()
         self.assertTrue(isinstance(rows, types.GeneratorType), True)
         self.assertEqual(len(list(rows)), sheet.nrows)
+
+    def test_iter(self):
+        sheet = self.book.sheet_by_index(SHEETINDEX)
+        rows = []
+        # check syntax
+        for row in sheet:
+            rows.append(row)
+        self.assertEqual(len(rows), sheet.nrows)
 
     def test_col_slice(self):
         sheet = self.book.sheet_by_index(SHEETINDEX)

--- a/tests/test_workbook.py
+++ b/tests/test_workbook.py
@@ -2,15 +2,19 @@
 
 from unittest import TestCase
 
+import xlrd
 from xlrd import open_workbook
 from xlrd.book import Book
 from xlrd.sheet import Sheet
 
 from .base import from_this_dir
 
+SHEETINDEX = 0
+NROWS = 15
+NCOLS = 13
+
 
 class TestWorkbook(TestCase):
-
     sheetnames = ['PROFILEDEF', 'AXISDEF', 'TRAVERSALCHAINAGE',
                   'AXISDATUMLEVELS', 'PROFILELEVELS']
 
@@ -43,3 +47,17 @@ class TestWorkbook(TestCase):
 
     def test_sheet_names(self):
         self.assertEqual(self.sheetnames, self.book.sheet_names())
+
+    def test_getitem_ix(self):
+        sheet = self.book[SHEETINDEX]
+        self.assertNotEqual(xlrd.empty_cell, sheet.cell(0, 0))
+        self.assertNotEqual(xlrd.empty_cell, sheet.cell(NROWS - 1, NCOLS - 1))
+
+    def test_getitem_name(self):
+        sheet = self.book[self.sheetnames[SHEETINDEX]]
+        self.assertNotEqual(xlrd.empty_cell, sheet.cell(0, 0))
+        self.assertNotEqual(xlrd.empty_cell, sheet.cell(NROWS - 1, NCOLS - 1))
+
+    def test_iter(self):
+        sheets = [sh.name for sh in self.book]
+        self.assertEqual(sheets, self.sheetnames)

--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -465,6 +465,14 @@ class Book(BaseObject):
         """
         return self._sheet_list[sheetx] or self.get_sheet(sheetx)
 
+    def __iter__(self):
+        """
+        Makes iteration through sheets of a book a little more straightforward.
+        Don't free resources after use since it can be called like `list(book)`
+        """
+        for i in range(self.nsheets):
+            yield self.sheet_by_index(i)
+
     def sheet_by_name(self, sheet_name):
         """
         :param sheet_name: Name of the sheet required.
@@ -475,6 +483,17 @@ class Book(BaseObject):
         except ValueError:
             raise XLRDError('No sheet named <%r>' % sheet_name)
         return self.sheet_by_index(sheetx)
+
+    def __getitem__(self, item):
+        """
+        Allow indexing with sheet name or index.
+        :param item: Name or index of sheet enquired upon
+        :return: :class:`~xlrd.sheet.Sheet`.
+        """
+        if isinstance(item, int):
+            return self.sheet_by_index(item)
+        else:
+            return self.sheet_by_name(item)
 
     def sheet_names(self):
         """

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -476,9 +476,26 @@ class Sheet(BaseObject):
             for colx in xrange(len(self._cell_values[rowx]))
         ]
 
+    def __getitem__(self, item):
+        """
+        Takes either rowindex or (rowindex, colindex) as an index,
+        and returns either row or cell respectively.
+        """
+        try:
+            rowix, colix = item
+        except TypeError:
+            # it's not a tuple (or of right size), let's try indexing as is
+            # if this is a problem, let this error propagate back
+            return self.row(item)
+        else:
+            return self.cell(rowix, colix)
+
     def get_rows(self):
         "Returns a generator for iterating through each row."
         return (self.row(index) for index in range(self.nrows))
+
+    # makes `for row in sheet` natural and intuitive
+    __iter__ = get_rows
 
     def row_types(self, rowx, start_colx=0, end_colx=None):
         """
@@ -2090,6 +2107,9 @@ class Sheet(BaseObject):
                 lt, idList, crwHeader, crwTotals, idFieldNext, cbFSData,
                 rupBuild, unusedShort,listFlags, lPosStmCache, cbStmCache,
                 cchStmCache, lem, rgbHashParam, cchName), file=self.logfile)
+
+    def __repr__(self):
+        return "Sheet {:>2}:<{}>".format(self.number, self.name)
 
 
 class MSODrawing(BaseObject):


### PR DESCRIPTION
Hi, I recently had to work with `xlrd` and found parts of it a bit counter-intuitive and needing to pore over the syntax given the lack of support for any magic methods.

Things that seem intuitive like `for sheet in book.sheets()` actually loads everything at once instead of as they're needed, and instead we should be doing `for book.sheet_by_index(i) for i in book.nsheets` which is not something I'd have done without looking at source.

Similarly iterating through rows, I find this show up on stackoverflow`[sh.row_values(rownum) for rownum in range(sh.nrows)]` when it could be `[row for row in sh.get_rows()]`. But this is non-obvious and people are sticking with what works first as there are a lot of methods to be looked at.

Getting rows has `sh.row(rowidx)` and for cells it's `sh.cell(rowidx, colidx)` and similarly `Book` has some counterintuitive naming for grabbing sheets.

Also, things like
```
>>> book.sheets()
[<xlrd.sheet.Sheet at 0x10d0ea438>,
 <xlrd.sheet.Sheet at 0x10d0ea400>,
 <xlrd.sheet.Sheet at 0x10d0ea908>,
 <xlrd.sheet.Sheet at 0x10d0ea940>,
 <xlrd.sheet.Sheet at 0x10d0ea978>]
```
make it even more confusing when working on a script.

This PR hopes to make things more intuitive
1. Sheet iteration can be be done as `for sheet in book`
2. Sheet selection can be done as `book[index]` or `book[name]`
3. Row iteration can be done as `for row in sheet`
4. Row selection can be as `sheet[rowix]`
5. Cell selection can be done as `sheet[rowix, colix]` or `sheet[rowix][colix]`.
6. Sheet now has a `repr` which gives names like "Sheet 0: <PROFILEDEF>" so the above print would look like
```
[Sheet  0:<PROFILEDEF>, 
 Sheet  1:<AXISDEF>,
 Sheet  2:<TRAVERSALCHAINAGE>, 
 Sheet  3:<AXISDATUMLEVELS>, 
 Sheet  4:<PROFILELEVELS>]
```
And of course some new tests to check everything is in order.