### PR TITLE
Classmethod for biff2_8_load and warnings for on_demand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
 
 after_success:
   - if [ $TOXENV != lint ]; then pip install coveralls; fi
+  - if [ $TOXENV == py27 ]; then pip install requests --upgrade; fi
   - if [ $TOXENV != lint ]; then coveralls; fi
 
 deploy:

--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -168,8 +168,7 @@ def dump(filename, outfile=sys.stdout, unnumbered=False):
     :param unnumbered: If true, omit offsets (for meaningful diffs).
     """
     from .biffh import biff_dump
-    bk = Book()
-    bk.biff2_8_load(filename=filename, logfile=outfile, )
+    bk = Book.biff2_8_load(filename=filename, logfile=outfile, )
     biff_dump(bk.mem, bk.base, bk.stream_len, 0, outfile, unnumbered)
 
 
@@ -182,6 +181,5 @@ def count_records(filename, outfile=sys.stdout):
     :param outfile: An open file, to which the summary is written.
     """
     from .biffh import biff_count_records
-    bk = Book()
-    bk.biff2_8_load(filename=filename, logfile=outfile, )
+    bk = Book.biff2_8_load(filename=filename, logfile=outfile, )
     biff_count_records(bk.mem, bk.base, bk.stream_len, outfile)

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -6,7 +6,7 @@
 from __future__ import print_function, unicode_literals
 
 import re
-import sys
+import warnings
 from os.path import join, normpath
 
 from .biffh import (
@@ -799,6 +799,8 @@ def open_workbook_2007_xml(zf,
     bk.use_mmap = False #### Not supported initially
     bk.on_demand = on_demand
     if on_demand:
+        warnings.warn("on_demand not yet implemented; falling back to False",
+                      RuntimeWarning)
         if verbosity:
             print("WARNING *** on_demand=True not yet implemented; falling back to False", file=bk.logfile)
         bk.on_demand = False


### PR DESCRIPTION
A couple of things that leapt out at me and bothered me more than it should.

- When on_demand didn't work, I would never have known due to the logging. This makes a more obvious runtimewarning for user
- changed `biff2_8_load` to a classmethod
- removed `sys` import from xlsx.py since it's unused
- fixed `time.time` to `perf_counter` since that's what's actually used.
