### PR TITLE
fixing coveralls for py27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
 
 after_success:
   - if [ $TOXENV != lint ]; then pip install coveralls; fi
+  - if [ $TOXENV == py27 ]; then pip install requests --upgrade; fi
   - if [ $TOXENV != lint ]; then coveralls; fi
 
 deploy:


### PR DESCRIPTION
coveralls for py27 will have an incompatible requests and urllib3 version unless the upgrade flag is given to pip.

This means py27 coverage doesn't show up in coveralls and it'll fail PRs for this reason.

(Merge this first pls)