### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# for container-y goodness:
+dist: xenial
 sudo: false
 cache: pip
 
@@ -8,8 +8,6 @@ matrix:
   include:
     - python: "3.7"
       env: TOXENV=py37
-      dist: xenial
-      sudo: required
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.5"


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release