### PR TITLE
Remove use of psyco

### DIFF
--- a/scripts/runxlrd.py
+++ b/scripts/runxlrd.py
@@ -31,9 +31,6 @@ xfc             Print "XF counts" and cell-type counts -- see code for details
 
 options = None
 if __name__ == "__main__":
-
-    PSYCO = 0
-
     import xlrd
     import sys
     import time
@@ -232,7 +229,7 @@ if __name__ == "__main__":
 
     def main(cmd_args):
         import optparse
-        global options, PSYCO
+        global options
         usage = "\n%prog [options] command [input-file-patterns]\n" + cmd_doc
         oparser = optparse.OptionParser(usage)
         oparser.add_option(
@@ -321,10 +318,6 @@ if __name__ == "__main__":
                     n_unreachable = gc.collect()
                     if n_unreachable:
                         print("GC before open:", n_unreachable, "unreachable objects")
-                if PSYCO:
-                    import psyco
-                    psyco.full()
-                    PSYCO = 0
                 try:
                     t0 = time.time()
                     bk = xlrd.open_workbook(
@@ -413,8 +406,5 @@ if __name__ == "__main__":
         import pstats
         p = pstats.Stats('YYYY.prof')
         p.strip_dirs().sort_stats('cumulative').print_stats(30)
-    elif firstarg == "psyco":
-        PSYCO = 1
-        main(av[1:])
     else:
         main(av)


### PR DESCRIPTION
The psyco package has been declared umaintained and dead. It is no
longer receiving bug fixes including for security issues. From
http://psyco.sourceforge.net/

> 12 March 2012
>
> Psyco is unmaintained and dead. Please look at PyPy for the
> state-of-the-art in JIT compilers for Python.

This avoid using and supporting an unmaintained package (since 2012).
Users should use PyPy for the latest and greatest in Python JIT.