### PR TITLE
Fix typo of field "book"

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -351,7 +351,7 @@ class X12Book(X12General):
             self.dump_elem(elem)
         nobj = Name()
         bk = self.bk
-        nobj.bk = bk
+        nobj.book = bk
         nobj.name_index = len(bk.name_obj_list)
         bk.name_obj_list.append(nobj)
         nobj.name = elem.get('name')


### PR DESCRIPTION
This causes errors to be lost as the error handling code attempts to access the logfile:

```
  File "/usr/local/lib/python2.7/dist-packages/xlrd/book.py", line 253, in cell
    self.dump(self.book.logfile,
AttributeError: 'NoneType' object has no attribute 'logfile'
```

See for example https://stackoverflow.com/questions/24437009/python-xlrd-named-range-value/28171108