### PR TITLE
Add store_formulas param

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -38,7 +38,9 @@ def open_workbook(filename=None,
                   encoding_override=None,
                   formatting_info=False,
                   on_demand=False,
-                  ragged_rows=False):
+                  ragged_rows=False,
+                  store_formulas=False,
+                  ):
     """
     Open a spreadsheet file for data extraction.
 
@@ -100,6 +102,10 @@ def open_workbook(filename=None,
       This can result in substantial memory savings if rows are of widely
       varying sizes. See also the :meth:`~xlrd.sheet.Sheet.row_len` method.
 
+    :param store_formulas:
+
+       The default value of `False` means formulas for Biff v5-8 will not attempt to be stored.
+
     :returns: An instance of the :class:`~xlrd.book.Book` class.
     """
 
@@ -136,6 +142,7 @@ def open_workbook(filename=None,
                 formatting_info=formatting_info,
                 on_demand=on_demand,
                 ragged_rows=ragged_rows,
+                store_formulas=store_formulas,
             )
             return bk
         if 'xl/workbook.bin' in component_names:

--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -71,7 +71,8 @@ def open_workbook_xls(filename=None,
                       logfile=sys.stdout, verbosity=0, use_mmap=USE_MMAP,
                       file_contents=None,
                       encoding_override=None,
-                      formatting_info=False, on_demand=False, ragged_rows=False):
+                      formatting_info=False, on_demand=False, ragged_rows=False,
+                      store_formulas=False):
     t0 = perf_counter()
     if TOGGLE_GC:
         orig_gc_enabled = gc.isenabled()
@@ -86,6 +87,7 @@ def open_workbook_xls(filename=None,
             formatting_info=formatting_info,
             on_demand=on_demand,
             ragged_rows=ragged_rows,
+            store_formulas=store_formulas,
         )
         t1 = perf_counter()
         bk.load_time_stage_1 = t1 - t0
@@ -591,6 +593,7 @@ class Book(BaseObject):
         self.style_name_map = {}
         self.mem = b''
         self.filestr = b''
+        self.store_forumlas = False
 
     def biff2_8_load(self, filename=None, file_contents=None,
                      logfile=sys.stdout, verbosity=0, use_mmap=USE_MMAP,
@@ -606,6 +609,7 @@ class Book(BaseObject):
         self.formatting_info = formatting_info
         self.on_demand = on_demand
         self.ragged_rows = ragged_rows
+        self.store_formulas = store_formulas
 
         if not file_contents:
             with open(filename, "rb") as f:
@@ -710,6 +714,7 @@ class Book(BaseObject):
             self._position,
             self._sheet_names[sh_number],
             sh_number,
+            self.store_formulas,
         )
         sh.read(self)
         self._sheet_list[sh_number] = sh


### PR DESCRIPTION
We have been using some mystical custom fork for `xlrd` but nobody know what this is doing. With this PR we want to have a git repo with that fork and hopefully rebase it frequently or making it easier to update in the future if needed.

See https://github.com/IntuitiveWebSolutions/BriteCore/pull/10990 currently failing with multiple of these:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/tmp/jenkins-9930284d/workspace/olutions_BriteCore_PR-10990-54JZFTJ74GQXXLN33A67AKKXGJMCZ4C3U4LFR6RVNUT3P2VLS65Q/tests/integration_tests/test_lib_reports_xls.py", line 1053, in test_normal_sweep
    xls_workbook = xlrd.open_workbook(self.xls_file, store_formulas=True)
TypeError: open_workbook() got an unexpected keyword argument 'store_formulas'
```