### PR TITLE
Clear PendingDeprecationWarning with `getiterator()`

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -59,6 +59,7 @@ def ensure_elementtree_imported(verbosity, logfile):
             ET_has_iterparse = True
         except NotImplementedError:
             pass
+    # defusedxml.cElementTree uses xml.etree.cElementTree.ElementTree in it.
     if is_defusedxml:
         import xml.etree.cElementTree as et_module
     else:

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -31,12 +31,15 @@ def ensure_elementtree_imported(verbosity, logfile):
     global ET, ET_has_iterparse, Element_has_iter
     if ET is not None:
         return
+    is_defusedxml = False
     if "IronPython" in sys.version:
         import xml.etree.ElementTree as ET
         #### 2.7.2.1: fails later with
         #### NotImplementedError: iterparse is not supported on IronPython. (CP #31923)
     else:
-        try: import defusedxml.cElementTree as ET
+        try:
+            import defusedxml.cElementTree as ET
+            is_defusedxml = True
         except ImportError:
             try: import xml.etree.cElementTree as ET
             except ImportError:
@@ -56,7 +59,11 @@ def ensure_elementtree_imported(verbosity, logfile):
             ET_has_iterparse = True
         except NotImplementedError:
             pass
-    Element_has_iter = hasattr(ET, 'ElementTree') and hasattr(ET.ElementTree, 'iter')
+    if is_defusedxml:
+        import xml.etree.cElementTree as et_module
+    else:
+        et_module = ET
+    Element_has_iter = hasattr(et_module, 'ElementTree') and hasattr(et_module.ElementTree, 'iter')
     if verbosity:
         etree_version = repr([
             (item, getattr(ET, item))


### PR DESCRIPTION
I'm not sure if this project is maintained actively but I'd like to make a PR for #315.

The variable `Element_has_iter` is wrongly `False` when using `defusedxml.cElementTree`. It seems to be caused since `defusedxml.cElementTree` internally uses `xml.etree.cElementTree.ElementTree` 
 but `defusedxml.cElementTree.ElementTree` (which is used for the check) doesn't exist.

Thank you in advance.