### PR TITLE
Strip non unicode spaces from last author

### DIFF
--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -1211,7 +1211,7 @@ class Book(BaseObject):
                 return
             strg = unpack_string(data, 0, self.encoding, lenlen=1)
         else:
-            strg = unpack_unicode(data, 0, lenlen=2)
+            strg = unpack_unicode(data.strip(), 0, lenlen=2)
         if DEBUG: fprintf(self.logfile, "WRITEACCESS: %d bytes; raw=%s %r\n", len(data), self.raw_user_name, strg)
         strg = strg.rstrip()
         self.user_name = strg


### PR DESCRIPTION
Strip spaces from last author to deal with malformed author fields.

I realise that it would be better to fix the source docs, but these are third party docs and we don't have the option to fix them at source.