### PR TITLE
Better iter detection

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -56,7 +56,7 @@ def ensure_elementtree_imported(verbosity, logfile):
             ET_has_iterparse = True
         except NotImplementedError:
             pass
-    Element_has_iter = hasattr(ET, 'ElementTree') and hasattr(ET.ElementTree, 'iter')
+    Element_has_iter = hasattr(ET.parse(BYTES_IO(b'<xml></xml>')), 'iter')
     if verbosity:
         etree_version = repr([
             (item, getattr(ET, item))


### PR DESCRIPTION
`defusedxml.cElementTree` results in an `xml.etree.(c)ElementTree.ElementTree`, which resulted `False` in the former expression, but should be `True`. This implementation inspects whether the actual tree object has an `iter` method.

Fixes
```
xlrd/xlsx.py:266: PendingDeprecationWarning: This method will be removed in future versions.  Use 'tree.iter()' or 'list(tree.iter())' instead.
    for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():
```