### PR TITLE
Fixed parsing cell comments from .xlsx under Windows

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -856,7 +856,7 @@ def open_workbook_2007_xml(zf,
             if reltype == 'comments':
                 comments_fname = x12sheet.relid2path.get(relid)
                 if comments_fname and comments_fname in component_names:
-                    comments_stream = zf.open(comments_fname)
+                    comments_stream = zf.open(component_names[comments_fname])
                     x12sheet.process_comments_stream(comments_stream)
                     del comments_stream
 

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -568,7 +568,7 @@ class X12Sheet(X12General):
             if self.verbosity >= 2:
                 self.dumpout('Id=%r Type=%r Target=%r', rid, reltype, target)
             self.relid2reltype[rid] = reltype
-            self.relid2path[rid] = normpath(join('xl/worksheets', target))
+            self.relid2path[rid] = normpath(join('xl/worksheets', target)).replace('\\', '/').lower()
 
     def process_comments_stream(self, stream):
         root = ET.parse(stream).getroot()


### PR DESCRIPTION
In version 1.2.0 the cell_note_map always returns no results when parsing .xlsx under windows. All unit tests from test_xlsx_comments.py are failing.

This small change fixes cell_note_map to work under Windows and is believed to make no change under other operating systems, as they use forward slashes anyway.