### PR TITLE
Indicate which pypi package is the official one.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ Password-protected files are not supported and cannot be read by this library.
 
 Quick start:
 
+.. code-block:: bash
+
+    pip install xlrd
+    
 .. code-block:: python
 
     import xlrd


### PR DESCRIPTION
Adding an indication that this project is available on pypi.
Specifically; it is helpful to indicate *which* pypi package should be used (as there are several, potentially nefarious clones).