### PR TITLE
Update utter_max_rows for BIFF<80 in sheet.py

### DIFF
--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -391,7 +391,7 @@ class Sheet(BaseObject):
         if self.biff_version >= 80:
             self.utter_max_rows = 65536
         else:
-            self.utter_max_rows = 16384
+            self.utter_max_rows = 32768
         self.utter_max_cols = 256
 
         self._first_full_rowx = -1


### PR DESCRIPTION
If a excelfile with older BIFF version has more lines that 16384 this line will throw a assertion error.

I have a old excel-file with around 30000 lines. This change will fix this. 

Is there a reason why you change limits between the BIFF-Version?