### PR TITLE
Change utter_max_rows limit for earlier BIFF versions

### DIFF
--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -388,10 +388,8 @@ class Sheet(BaseObject):
         self._ixfe = None # BIFF2 only
         self._cell_attr_to_xfx = {} # BIFF2.0 only
 
-        if self.biff_version >= 80:
-            self.utter_max_rows = 65536
-        else:
-            self.utter_max_rows = 16384
+        self.utter_max_rows = 65536
+
         self.utter_max_cols = 256
 
         self._first_full_rowx = -1


### PR DESCRIPTION
If older excel has too many lines, and assertion error will be thrown.

Deleted if condition for utter_max_rows to see if some tests will fail