### PR TITLE
Fix bare except clauses in xlrd/book.py and xlrd/sheet.py

### DIFF
--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -115,7 +115,7 @@ def open_workbook_xls(filename=None,
             )
         t2 = perf_counter()
         bk.load_time_stage_2 = t2 - t1
-    except:
+    except Exception:
         bk.release_resources()
         raise
     # normal exit
@@ -1424,7 +1424,7 @@ def unpack_SST_table(datatab, nstrings):
                 # if DEBUG: print "SST U16: nchars=%d pos=%d rawstrg=%r" % (nchars, pos, rawstrg)
                 try:
                     accstrg += unicode(rawstrg, "utf_16_le")
-                except:
+                except Exception:
                     # print "SST U16: nchars=%d pos=%d rawstrg=%r" % (nchars, pos, rawstrg)
                     # Probable cause: dodgy data e.g. unfinished surrogate pair.
                     # E.g. file unicode2.xls in pyExcelerator's examples has cells containing

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -707,7 +707,7 @@ class Sheet(BaseObject):
             values_row[colx] = value
             if fmt_info:
                 fmt_row[colx] = xf_index
-        except:
+        except Exception:
             print("put_cell", rowx, colx, file=self.logfile)
             raise
 
@@ -776,10 +776,10 @@ class Sheet(BaseObject):
                 self._cell_values[rowx][colx] = value
                 if self.formatting_info:
                     self._cell_xf_indexes[rowx][colx] = xf_index
-            except:
+            except Exception:
                 print("put_cell", rowx, colx, file=self.logfile)
                 raise
-        except:
+        except Exception:
             print("put_cell", rowx, colx, file=self.logfile)
             raise
 


### PR DESCRIPTION
Replace 5 bare `except:` clauses with `except Exception:` across two files.

**xlrd/book.py** (2 fixes):
- Stage-2 load error handler that calls `bk.release_resources()` and re-raises
- Unicode string accumulation fallback

**xlrd/sheet.py** (3 fixes):
- `put_cell` error handlers that log and re-raise

Bare `except:` catches `BaseException` (including `SystemExit` and `KeyboardInterrupt`), which can suppress signals. All of these handlers re-raise or are debug fallbacks, so `except Exception:` is the correct specific type.